### PR TITLE
Atreus Qukeys customizations

### DIFF
--- a/Atreus/Atreus.ino
+++ b/Atreus/Atreus.ino
@@ -40,8 +40,42 @@
 
 enum {
   MACRO_QWERTY,
-  MACRO_VERSION_INFO
+  MACRO_VERSION_INFO,
+
+  // These are special Qukeys macros to dynamically control Qukeys tap-repeat behavior
+  // by modifying Qukeys.setMaxIntervalForTapRepeat(timeout) value.
+  // The numeric references are for easily configuring the Macros from Chrysalis editor.
+
+  // Type out current settings for debugging
+  MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_INFO,   // 2
+
+  // Decrease the tap-repeat timeout
+  MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_DEC,    // 3
+
+  // Increase the tap-repeat timeout
+  MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_INC,    // 4
+
+  // Toggle the tap-repeat timeout off, temporarily setting it to 0 and then back to previous value
+  MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_TOGGLE_OFF,  // 5
+
+  // Toggle the tap-repeat timeout to max temporarily. Next activation will return to previous value.
+  MACROS_QUKEYS_TAP_REPEAT_TIMEOUT_TOGGLE_MAX  // 6
 };
+
+#define QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT 120
+#define QUKEYS_TAP_REPEAT_TIMEOUT_MIN     100
+#define QUKEYS_TAP_REPEAT_TIMEOUT_MAX     220
+#define QUKEYS_TAP_REPEAT_TIMEOUT_DELTA   10
+
+// Qukeys Tap-Repeat State
+typedef enum {
+  QTR_STATE_ENABLED,
+  QTR_STATE_OFF,
+  QTR_STATE_MAX
+} QtrState_t;
+
+QtrState_t QukeysTapRepeatState = QTR_STATE_ENABLED;
+uint8_t QukeysTapRepeatTimeout = QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT;
 
 #define Key_Exclamation LSHIFT(Key_1)
 #define Key_At          LSHIFT(Key_2)
@@ -173,6 +207,95 @@ KALEIDOSCOPE_INIT_PLUGINS(
   // GeminiPR,
 );
 
+void typeDigit(uint8_t digit) {
+  // Using Macros type the single digit 0-9
+  if (digit > 9) {
+    Macros.type(PSTR("???"));
+    return;
+  }
+  const char* digits[] = {
+    PSTR("0"), PSTR("1"), PSTR("2"), PSTR("3"), PSTR("4"), PSTR("5"), PSTR("6"), PSTR("7"), PSTR("8"), PSTR("9")
+  };
+  Macros.type(digits[digit]);
+}
+
+void typeValue(uint8_t value) {
+  // Using Macros type each digit of the value given an unsigned 8-bit value.
+  // pretty pathetic but for small numbers it's okay.
+  if (value >= 10) {
+    uint8_t digit = value % 10;
+    value = value / 10;
+    typeValue(value); // will never recurse more than 3 times.
+    typeDigit(digit);
+  } else {
+    typeDigit(value);
+  }
+}
+
+void typeQukeysTapRepeatTimeout() {
+  // Using Macros type the value for Qukeys tap-repeat timeout
+  Macros.type(PSTR("Keyboardio Atreus Qukeys tap-repeat: "));
+  typeValue(QukeysTapRepeatTimeout);
+  if (QukeysTapRepeatState == QTR_STATE_OFF) {
+    Macros.type(PSTR(" [TOGGLED OFF]"));
+  }
+  else if (QukeysTapRepeatState == QTR_STATE_MAX) {
+    Macros.type(PSTR(" [TOGGLED MAX]"));
+  }
+  Macros.type(PSTR(" MIN="));
+  typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_MIN);
+  Macros.type(PSTR(" MAX="));
+  typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_MAX);
+  Macros.type(PSTR(" DEFAULT="));
+  typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT);
+  Macros.type(PSTR(" DELTA="));
+  typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_DELTA);
+}
+
+void increaseQukeysTapRepeatTimeout() {
+  // increase the tap-repeat timeout value and switch state to enabled if in another state
+  QukeysTapRepeatTimeout =
+    min(QukeysTapRepeatTimeout + QUKEYS_TAP_REPEAT_TIMEOUT_DELTA, QUKEYS_TAP_REPEAT_TIMEOUT_MAX);
+  Qukeys.setMaxIntervalForTapRepeat(QukeysTapRepeatTimeout);
+  QukeysTapRepeatState = QTR_STATE_ENABLED;
+}
+
+void decreaseQukeysTapRepeatTimeout() {
+  // decrease the tap-repeat timeout value and switch state to enabled if in another state
+  QukeysTapRepeatTimeout =
+    max(QukeysTapRepeatTimeout - QUKEYS_TAP_REPEAT_TIMEOUT_DELTA, QUKEYS_TAP_REPEAT_TIMEOUT_MIN);
+  Qukeys.setMaxIntervalForTapRepeat(QukeysTapRepeatTimeout);
+  QukeysTapRepeatState = QTR_STATE_ENABLED;
+}
+
+void toggleOffQukeysTapRepeatTimeout() {
+  // toggle tap-repeat between off/previous value
+  // if toggled off, toggle back to enabled.
+  // if enabled or if toggled to max, toggle to off.
+  if (QukeysTapRepeatState == QTR_STATE_OFF) {
+    Qukeys.setMaxIntervalForTapRepeat(QukeysTapRepeatTimeout);
+    QukeysTapRepeatState = QTR_STATE_ENABLED;
+  }
+  else {
+    Qukeys.setMaxIntervalForTapRepeat(0);
+    QukeysTapRepeatState = QTR_STATE_OFF;
+  }
+}
+
+void toggleMaxQukeysTapRepeatTimeout() {
+  // toggle tap-repeat between max/previous value
+  // if toggled to max, toggle back to enabled
+  // if enabled or togged to off, toggle to max
+  if (QukeysTapRepeatState == QTR_STATE_MAX) {
+    Qukeys.setMaxIntervalForTapRepeat(QukeysTapRepeatTimeout);
+    QukeysTapRepeatState = QTR_STATE_ENABLED;
+  }
+  else {
+    Qukeys.setMaxIntervalForTapRepeat(QUKEYS_TAP_REPEAT_TIMEOUT_MAX);
+    QukeysTapRepeatState = QTR_STATE_MAX;
+  }
+}
+
 const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
   if (keyToggledOn(event.state)) {
     switch (macro_id) {
@@ -184,9 +307,23 @@ const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
       Layer.move(QWERTY);
       break;
     case MACRO_VERSION_INFO:
-      Macros.type(PSTR("Keyboardio Atreus - Kaleidoscope "));
+      Macros.type(("Keyboardio Atreus - Kaleidoscope "));
       Macros.type(PSTR(BUILD_INFORMATION));
       break;
+    case MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_INFO:
+      typeQukeysTapRepeatTimeout();
+      break;
+    case MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_INC:
+      increaseQukeysTapRepeatTimeout();
+      break;
+    case MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_DEC:
+      decreaseQukeysTapRepeatTimeout();
+      break;
+    case MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_TOGGLE_OFF:
+      toggleOffQukeysTapRepeatTimeout();
+      break;
+    case MACROS_QUKEYS_TAP_REPEAT_TIMEOUT_TOGGLE_MAX:
+      toggleMaxQukeysTapRepeatTimeout();
     default:
       break;
     }
@@ -214,7 +351,7 @@ void setup() {
   Qukeys.setOverlapThreshold(100);         // default 80
   Qukeys.setMinimumHoldTime(500);          // default 50
   Qukeys.setMinimumPriorInterval(350);      // default 75
-  Qukeys.setMaxIntervalForTapRepeat(130);  // default 200
+  Qukeys.setMaxIntervalForTapRepeat(QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT);  // default 200
 }
 
 void loop() {

--- a/Atreus/Atreus.ino
+++ b/Atreus/Atreus.ino
@@ -212,8 +212,8 @@ void setup() {
   // Tweak Qukeys to prevent unintended modifiers with home row mods:
   // https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-Qukeys.html
   Qukeys.setOverlapThreshold(100);         // default 80
-  Qukeys.setMinimumHoldTime(150);          // default 50
-  Qukeys.setMinimumPriorInterval(80);      // default 75
+  Qukeys.setMinimumHoldTime(500);          // default 50
+  Qukeys.setMinimumPriorInterval(350);      // default 75
   Qukeys.setMaxIntervalForTapRepeat(130);  // default 200
 }
 

--- a/Atreus/README.md
+++ b/Atreus/README.md
@@ -1,0 +1,64 @@
+# Atreus
+
+This is my custom Kaleidoscope firmware for the [Keyboardio Atreus](https://shop.keyboard.io/products/keyboardio-atreus#), a minimal 44 key, split, columnar, ergonomic mechanical keyboard.
+
+My Atreus layout is inspired by [Miryoku](https://github.com/manna-harbour/miryoku/), with the following notable differences and features:
+
+* QWERTY layout for base layer
+* vi-style navigation vs Miryoku arrows on home keys
+* Additional macOS shortcuts on `nav` and `mouse` layers
+* Swap `space` and `backspace` to match the layout on the [Keyboardio Model 100](https://shop.keyboard.io/products/model-100) I'm already familiar with.
+* Kaleidoscope [MouseKeys Warping](https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-MouseKeys.html#warping) with 2x2 grid
+* Implementation differences to accommodate Kaleidoscope firmware and customizations for secondary modifier actions
+* The Keyboardio Atreus has 44 keys and I make regular use of 38. The three outer keys on the last row of each hand are mostly ignored for regular use.
+
+See [Miryoku Alternative Layout](https://github.com/manna-harbour/miryoku/tree/master/docs/reference#alternative-layouts) for some documented differences from default Miryoku layout.
+
+## Qukeys and Home Row Mods
+
+Until I learned about and started using [home row mods](https://precondition.github.io/home-row-mods), I was mostly unimpressed and ineffective with the Atreus. There just were not enough keys to comfortably accommodate how I was using the keyboard. That changed when I started using home *row mods*, or secondary actions on the home row keys that take on modifier keys such as `shift`, `control`, `alt`, when held and normal keys when tapped.
+
+My only problem was that when typing quickly (and sometimes not so quickly) with the default Kaleidoscope firmware, I would frequently accidentally trigger unintentional modifier actions and run into other problems such as repeated home row keys not getting registered. This is what led me to customize and compile my own firmware.
+
+### My Qukeys Settings
+
+Home row mods and secondary actions in general, such as secondary actions on the thumb cluster keys, are controlled in Kaleidoscope using the [Qukeys](https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-Qukeys.html) plugin.
+
+In order to reduce unintentionally activating modifiers and secondary actions while typing quickly, the following settings are changed from the default behavior:
+
+* [`.setMaxIntervalForTapRepeat(timeout)`](https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-Qukeys.html#setmaxintervalfortaprepeat-timeout): set to less than the default and see [Dynamic Adjustments](#dynamic-adjustments) below.
+* [`.setOverlapThreshold(percentage)`](https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-Qukeys.html#setoverlapthreshold-percentage): set to 100% and still not perfect.
+* [`.setMinimumHoldTime(min_hold_time)`](https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-Qukeys.html#setoverlapthreshold-percentage): increased significantly from the default.
+* [`.setMinimumPriorInterval(min_interval)`](https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-Qukeys.html#setminimumpriorinterval-min-interval): increased significantly from the default.
+
+### Dynamic Adjustments
+
+I reduced [`.setMaxIntervalForTapRepeat(timeout)`](https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-Qukeys.html#setmaxintervalfortaprepeat-timeout) to significantly lower values (e.g, less than 140 ms) than the default of 200 ms, in order to mitigate an issue where repeated quickly tapped home row keys would not register (e.g., typing "less" would only register one "s"). But this led to another problem: I could not tap and hold a key to have it repeat ([Tap-Repeat Behavior](https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-Qukeys.html#tap-repeat-behaviour)). For most keys not having tap-repeat is not a huge problem, but for keys such as vi-style navigation, `backspace`, `space`, etc., this was much more of a nuisance.
+
+To mitigate issues with the Qukeys Tap-Repeat behavior, I created the ability to dynamically modify some Qukey settings using configured macros which I map to keys on the `fun` layer. The macros are:
+
+* `MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_INFO`: type out info on current settings for debugging.
+* `MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_DEC`: decrease the tap-repeat timeout.
+* `MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_INC`: increase the tap-repeat timeout.
+* `MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_TOGGLE_OFF`: toggle the tap-repeat timeout between current value and 0 to temporarily disable it.
+* `MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_TOGGLE_MAX`: toggle the tap-repeat timeout between current value and its max, to temporarily allow easier repeating of held keys.
+
+In general, I prefer values of 130-140 ms for the tap-repeat timeout interval. But when I want to occasionally take advantage of the tap-repeat behavior, I'm now able to quickly temporarily modify the settings.
+
+## Layout Experiments
+
+Some alternative layouts to solve specific issues which I'm still experimenting with.
+
+### Alternative 01
+
+Experimental alternative layout to solve specific issues with the original layout:
+
+1. Using home row mods for `shift` is challenging when typing uppercase or mixed case words that alternate between hands, especially words containing letters on the home row. It would be nice to have access to `shift` on the thumb keys.
+1. Copying and pasting is not easy when the right hand is on the mouse. On a normal QWERTY keyboard this is trivial with the left hand. However, with the original layout it requires a difficult contortion or chording two keys with the left hand.
+
+Updates to address these issues:
+
+1. add `shift` as secondary modifier on outer thumb keys (third from center on Atreus), repositioning layer shift keys for `fun` and `media` layers.
+1. mirror the `paste`, `copy`, `cut` keys on the `mouse` layer to left hand so these keys can easily be used with either hand when the right hand is on the mouse.
+
+See `layout_alt01.json` for details.

--- a/Atreus/layout_alt01.json
+++ b/Atreus/layout_alt01.json
@@ -98,10 +98,10 @@
         "categories": ["modifier", "dualuse", "ctrl"]
       },
       {
-        "code": 52271,
+        "code": 52527,
         "baseCode": 29,
-        "label": {"hint": "Layer #4/", "base": "z"},
-        "target": 4,
+        "label": {"hint": "Layer #5/", "base": "z"},
+        "target": 5,
         "rangeStart": 51218,
         "categories": ["layer", "dualuse"]
       },
@@ -135,12 +135,12 @@
         "categories": ["modifier"]
       },
       {
-        "code": 52283,
+        "code": 49466,
         "baseCode": 41,
-        "label": {"hint": "Layer #4/", "base": "Esc"},
-        "target": 4,
-        "rangeStart": 51218,
-        "categories": ["layer", "dualuse"]
+        "label": {"hint": "Shift/", "base": "Esc"},
+        "modifier": "Shift",
+        "rangeStart": 49169,
+        "categories": ["modifier", "dualuse", "shift"]
       },
       {
         "code": 52028,
@@ -154,10 +154,10 @@
         "categories": ["layer", "dualuse"]
       },
       {
-        "code": 52541,
+        "code": 52285,
         "baseCode": 43,
-        "label": {"hint": "Layer #5/", "base": "Tab"},
-        "target": 5,
+        "label": {"hint": "Layer #4/", "base": "Tab"},
+        "target": 4,
         "rangeStart": 51218,
         "categories": ["layer", "dualuse"]
       },
@@ -178,14 +178,20 @@
         "categories": ["layer", "dualuse"]
       },
       {
-        "code": 52806,
+        "code": 49477,
         "baseCode": 52,
-        "label": {"hint": "Layer #6/", "base": "'"},
-        "target": 6,
-        "rangeStart": 51218,
-        "categories": ["layer", "dualuse"]
+        "label": {"hint": "Shift/", "base": "'"},
+        "modifier": "Shift",
+        "rangeStart": 49169,
+        "categories": ["modifier", "dualuse", "shift"]
       },
-      {"code": 45, "label": {"base": "-", "shifted": "_"}},
+      {
+        "code": 17456,
+        "label": {"hint": "ShiftTo", "base": "#6"},
+        "target": 6,
+        "rangeStart": 17450,
+        "categories": ["layer", "shifttolayer"]
+      },
       {
         "code": 227,
         "label": {"base": {"full": "Command", "1u": "Cmd", "short": "⌘"}},
@@ -284,8 +290,16 @@
       {"code": 32, "label": {"base": "3", "shifted": "#"}},
       {"code": 49, "label": {"base": "\\", "shifted": "|"}},
       {"code": 56, "label": {"base": "/", "shifted": "?"}},
-      {"code": 40, "label": {"base": "Enter"}},
-      {"code": 44, "label": {"base": "Space"}},
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
       {
         "code": 65535,
         "label": {"base": {"full": "Transparent", "1u": " "}},
@@ -331,7 +345,11 @@
         "label": {"base": {"full": "Transparent", "1u": " "}},
         "categories": ["blanks"]
       },
-      {"code": 44, "label": {"base": "Space"}},
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
       {
         "code": 65535,
         "label": {"base": {"full": "Transparent", "1u": " "}},
@@ -409,8 +427,16 @@
         "label": {"base": {"full": "Transparent", "1u": " "}},
         "categories": ["blanks"]
       },
-      {"code": 47, "label": {"base": "[", "shifted": "{"}},
-      {"code": 48, "label": {"base": "]", "shifted": "}"}},
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
       {
         "code": 2099,
         "label": {"hint": {"full": "", "1u": ""}, "base": ":"},
@@ -516,8 +542,6 @@
         "categories": ["with-modifiers", "shift"],
         "baseCode": 56
       },
-      {"code": 40, "label": {"base": "Enter"}},
-      {"code": 44, "label": {"base": "Space"}},
       {
         "code": 65535,
         "label": {"base": {"full": "Transparent", "1u": " "}},
@@ -538,8 +562,26 @@
         "label": {"base": {"full": "Transparent", "1u": " "}},
         "categories": ["blanks"]
       },
-      {"code": 47, "label": {"base": "[", "shifted": "{"}},
-      {"code": 48, "label": {"base": "]", "shifted": "}"}},
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
       {
         "code": 65535,
         "label": {"base": {"full": "Transparent", "1u": " "}},
@@ -564,8 +606,8 @@
         "baseCode": 45
       },
       {
-        "code": 0,
-        "label": {"base": {"full": "Blocked", "1u": "Blkd"}},
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
         "categories": ["blanks"]
       },
       {
@@ -812,32 +854,28 @@
     ],
     [
       {
-        "code": 18846,
-        "label": {"base": {"full": "Lock Screen", "1u": "Lock"}},
-        "categories": ["platform_apple"]
+        "code": 4125,
+        "label": {"hint": {"full": "Command+", "1u": "⌘+"}, "base": "z"},
+        "categories": ["with-modifiers", "gui"],
+        "baseCode": 29
       },
       {
-        "code": 336,
-        "label": {
-          "hint": {"full": "Ctrl+", "1u": "C+"},
-          "base": {"full": "Left Arrow", "1u": "←"}
-        },
-        "categories": ["with-modifiers", "ctrl"],
-        "baseCode": 80
+        "code": 4123,
+        "label": {"hint": {"full": "Command+", "1u": "⌘+"}, "base": "x"},
+        "categories": ["with-modifiers", "gui"],
+        "baseCode": 27
       },
       {
-        "code": 19103,
-        "label": {"base": {"full": "Exposé"}},
-        "categories": ["platform_apple"]
+        "code": 4102,
+        "label": {"hint": {"full": "Command+", "1u": "⌘+"}, "base": "c"},
+        "categories": ["with-modifiers", "gui"],
+        "baseCode": 6
       },
       {
-        "code": 335,
-        "label": {
-          "hint": {"full": "Ctrl+", "1u": "C+"},
-          "base": {"full": "Right Arrow", "1u": "→"}
-        },
-        "categories": ["with-modifiers", "ctrl"],
-        "baseCode": 79
+        "code": 4121,
+        "label": {"hint": {"full": "Command+", "1u": "⌘+"}, "base": "v"},
+        "categories": ["with-modifiers", "gui"],
+        "baseCode": 25
       },
       {
         "code": 20517,
@@ -964,19 +1002,9 @@
         "categories": ["mousekeys"]
       },
       {
-        "code": 4149,
-        "label": {"hint": {"full": "Command+", "1u": "⌘+"}, "base": "`"},
-        "categories": ["with-modifiers", "gui"],
-        "baseCode": 53
-      },
-      {
-        "code": 4688,
-        "label": {
-          "hint": {"full": "Alt+Command+", "1u": "A+⌘+"},
-          "base": {"full": "Left Arrow", "1u": "←"}
-        },
-        "categories": ["with-modifiers", "alt", "gui"],
-        "baseCode": 80
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
         "code": 65535,
@@ -984,25 +1012,24 @@
         "categories": ["blanks"]
       },
       {
-        "code": 4687,
-        "label": {
-          "hint": {"full": "Alt+Command+", "1u": "A+⌘+"},
-          "base": {"full": "Right Arrow", "1u": "→"}
-        },
-        "categories": ["with-modifiers", "alt", "gui"],
-        "baseCode": 79
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 4143,
-        "label": {"hint": {"full": "Command+", "1u": "⌘+"}, "base": "["},
-        "categories": ["with-modifiers", "gui"],
-        "baseCode": 47
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 4144,
-        "label": {"hint": {"full": "Command+", "1u": "⌘+"}, "base": "]"},
-        "categories": ["with-modifiers", "gui"],
-        "baseCode": 48
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
         "code": 20576,
@@ -1511,18 +1538,14 @@
         "categories": ["macros"]
       },
       {
-        "code": 17492,
-        "label": {"hint": "MoveTo", "base": "#0"},
-        "target": 0,
-        "rangeStart": 17492,
-        "categories": ["layer", "movetolayer"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 17499,
-        "label": {"hint": "MoveTo", "base": "#7"},
-        "target": 7,
-        "rangeStart": 17492,
-        "categories": ["layer", "movetolayer"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
         "code": 65535,
@@ -1532,6 +1555,11 @@
       {"code": 101, "label": {"base": "Menu"}},
       {"code": 44, "label": {"base": "Space"}},
       {"code": 43, "label": {"base": "Tab"}},
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
       {
         "code": 65535,
         "label": {"base": {"full": "Transparent", "1u": " "}},
@@ -1554,151 +1582,251 @@
         "categories": ["macros"]
       },
       {
-        "code": 24578,
-        "label": {"hint": "Macro", "base": "#2"},
-        "rangeStart": 24576,
-        "categories": ["macros"]
-      },
-      {
         "code": 65535,
         "label": {"base": {"full": "Transparent", "1u": " "}},
         "categories": ["blanks"]
       }
     ],
     [
-      {"code": 20, "label": {"base": "q", "shifted": "Q"}},
-      {"code": 26, "label": {"base": "w", "shifted": "W"}},
-      {"code": 8, "label": {"base": "e", "shifted": "E"}},
-      {"code": 21, "label": {"base": "r", "shifted": "R"}},
-      {"code": 23, "label": {"base": "t", "shifted": "T"}},
       {
-        "code": 0,
-        "label": {"base": {"full": "Blocked", "1u": "Blkd"}},
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
         "categories": ["blanks"]
       },
       {
-        "code": 0,
-        "label": {"base": {"full": "Blocked", "1u": "Blkd"}},
-        "categories": ["blanks"]
-      },
-      {"code": 28, "label": {"base": "y", "shifted": "Y"}},
-      {"code": 24, "label": {"base": "u", "shifted": "U"}},
-      {"code": 12, "label": {"base": "i", "shifted": "I"}},
-      {"code": 18, "label": {"base": "o", "shifted": "O"}},
-      {"code": 19, "label": {"base": "p", "shifted": "P"}},
-      {"code": 4, "label": {"base": "a", "shifted": "A"}},
-      {"code": 22, "label": {"base": "s", "shifted": "S"}},
-      {"code": 7, "label": {"base": "d", "shifted": "D"}},
-      {"code": 9, "label": {"base": "f", "shifted": "F"}},
-      {"code": 10, "label": {"base": "g", "shifted": "G"}},
-      {
-        "code": 0,
-        "label": {"base": {"full": "Blocked", "1u": "Blkd"}},
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
         "categories": ["blanks"]
       },
       {
-        "code": 0,
-        "label": {"base": {"full": "Blocked", "1u": "Blkd"}},
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
         "categories": ["blanks"]
       },
-      {"code": 11, "label": {"base": "h", "shifted": "H"}},
-      {"code": 13, "label": {"base": "j", "shifted": "J"}},
-      {"code": 14, "label": {"base": "k", "shifted": "K"}},
-      {"code": 15, "label": {"base": "l", "shifted": "L"}},
-      {"code": 51, "label": {"base": ";", "shifted": ":"}},
-      {"code": 29, "label": {"base": "z", "shifted": "Z"}},
-      {"code": 27, "label": {"base": "x", "shifted": "X"}},
-      {"code": 6, "label": {"base": "c", "shifted": "C"}},
-      {"code": 25, "label": {"base": "v", "shifted": "V"}},
-      {"code": 5, "label": {"base": "b", "shifted": "B"}},
-      {"code": 53, "label": {"base": "`", "shifted": "~"}},
-      {"code": 49, "label": {"base": "\\", "shifted": "|"}},
-      {"code": 17, "label": {"base": "n", "shifted": "N"}},
-      {"code": 16, "label": {"base": "m", "shifted": "M"}},
-      {"code": 54, "label": {"base": ",", "shifted": "<"}},
-      {"code": 55, "label": {"base": ".", "shifted": ">"}},
-      {"code": 56, "label": {"base": "/", "shifted": "?"}},
       {
-        "code": 225,
-        "label": {"base": "Shift"},
-        "location": "left",
-        "categories": ["modifier"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 224,
-        "label": {"base": {"full": "Control", "1u": "Ctrl"}},
-        "location": "left",
-        "categories": ["modifier"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 227,
-        "label": {"base": {"full": "Command", "1u": "Cmd", "short": "⌘"}},
-        "location": "left",
-        "categories": ["modifier"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 52539,
-        "baseCode": 41,
-        "label": {"hint": "Layer #5/", "base": "Esc"},
-        "target": 5,
-        "rangeStart": 51218,
-        "categories": ["layer", "dualuse"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 52028,
-        "baseCode": 42,
-        "label": {
-          "hint": "Layer #3/",
-          "base": {"full": "Backspace", "1u": "Bksp"}
-        },
-        "target": 3,
-        "rangeStart": 51218,
-        "categories": ["layer", "dualuse"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 52285,
-        "baseCode": 43,
-        "label": {"hint": "Layer #4/", "base": "Tab"},
-        "target": 4,
-        "rangeStart": 51218,
-        "categories": ["layer", "dualuse"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 51770,
-        "baseCode": 40,
-        "label": {"hint": "Layer #2/", "base": "Enter"},
-        "target": 2,
-        "rangeStart": 51218,
-        "categories": ["layer", "dualuse"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 51518,
-        "baseCode": 44,
-        "label": {"hint": "Layer #1/", "base": "Space"},
-        "target": 1,
-        "rangeStart": 51218,
-        "categories": ["layer", "dualuse"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 52806,
-        "baseCode": 52,
-        "label": {"hint": "Layer #6/", "base": "'"},
-        "target": 6,
-        "rangeStart": 51218,
-        "categories": ["layer", "dualuse"]
-      },
-      {"code": 45, "label": {"base": "-", "shifted": "_"}},
-      {
-        "code": 227,
-        "label": {"base": {"full": "Command", "1u": "Cmd", "short": "⌘"}},
-        "location": "left",
-        "categories": ["modifier"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       },
       {
-        "code": 229,
-        "label": {"base": "Shift"},
-        "location": "right",
-        "categories": ["modifier"]
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
+      },
+      {
+        "code": 65535,
+        "label": {"base": {"full": "Transparent", "1u": " "}},
+        "categories": ["blanks"]
       }
     ],
     [
@@ -1948,7 +2076,7 @@
   "palette": [],
   "deviceConfiguration": {
     "escape_oneshot.cancel_key": "41",
-    "keymap.custom": "20 26 8 21 23 0 0 28 24 12 18 19 49173 49703 49944 49434 10 0 0 11 49438 49951 49696 49220 52271 27 6 25 5 53 49 17 16 54 55 56 225 224 227 52283 52028 52541 51770 51518 52806 45 227 229 47 36 37 38 48 2087 51 2086 2087 2095 2096 42 51 33 34 35 46 224 53 65535 225 227 226 224 53 30 31 32 49 56 40 44 65535 65535 65535 65535 17409 65535 65535 55 39 45 65535 44 65535 65535 65535 65535 2095 2084 2085 2086 2096 65535 65535 65535 65535 65535 47 48 2099 2081 2082 2083 2094 65535 65535 65535 225 227 226 224 2101 2078 2079 2080 2097 2104 40 44 65535 65535 65535 65535 47 48 65535 2086 2087 2093 0 65535 65535 65535 65535 65535 18846 336 19103 335 4144 65535 24 6173 4121 4102 4123 4125 224 226 227 225 4143 65535 65535 80 81 82 79 57 4149 4688 19106 4687 4143 4144 65535 74 78 75 77 73 65535 65535 65535 65535 0 65535 40 42 76 65535 65535 65535 18846 336 19103 335 20517 20576 224 6173 4121 4102 4123 20521 224 226 227 225 20518 20520 0 20484 20482 20481 20488 20522 4149 4688 65535 4687 4143 4144 20576 20500 20497 20498 20504 20576 65535 65535 65535 65535 65535 65535 20546 20545 20548 65535 65535 65535 18846 336 19103 335 65535 4396 224 65535 18544 18543 65535 4396 224 226 227 225 65535 65535 65535 18614 18666 18665 18613 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 18615 18637 18658 65535 65535 65535 69 64 65 66 70 65535 65535 65535 65535 65535 65535 65535 68 61 62 63 71 65535 65535 65535 225 227 226 224 67 58 59 60 72 19101 65535 24581 24579 24580 24578 24582 17492 17499 65535 101 44 43 65535 65535 0 24577 24578 65535 20 26 8 21 23 0 0 28 24 12 18 19 4 22 7 9 10 0 0 11 13 14 15 51 29 27 6 25 5 53 49 17 16 54 55 56 225 224 227 52539 52028 52285 51770 51518 52806 45 227 229 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535",
+    "keymap.custom": "20 26 8 21 23 0 0 28 24 12 18 19 49173 49703 49944 49434 10 0 0 11 49438 49951 49696 49220 52527 27 6 25 5 53 49 17 16 54 55 56 225 224 227 49466 52028 52285 51770 51518 49477 17456 227 229 47 36 37 38 48 2087 51 2086 2087 2095 2096 42 51 33 34 35 46 224 53 65535 225 227 226 224 53 30 31 32 49 56 65535 65535 65535 65535 65535 65535 17409 65535 65535 55 39 45 65535 65535 65535 65535 65535 65535 2095 2084 2085 2086 2096 65535 65535 65535 65535 65535 65535 65535 2099 2081 2082 2083 2094 65535 65535 65535 225 227 226 224 2101 2078 2079 2080 2097 2104 65535 65535 65535 65535 65535 65535 65535 65535 65535 2086 2087 2093 65535 65535 65535 65535 65535 65535 18846 336 19103 335 4144 65535 24 6173 4121 4102 4123 4125 224 226 227 225 4143 65535 65535 80 81 82 79 57 4149 4688 19106 4687 4143 4144 65535 74 78 75 77 73 65535 65535 65535 65535 0 65535 40 42 76 65535 65535 65535 4125 4123 4102 4121 20517 20576 224 6173 4121 4102 4123 20521 224 226 227 225 20518 20520 0 20484 20482 20481 20488 20522 65535 65535 65535 65535 65535 65535 20576 20500 20497 20498 20504 20576 65535 65535 65535 65535 65535 65535 20546 20545 20548 65535 65535 65535 18846 336 19103 335 65535 4396 224 65535 18544 18543 65535 4396 224 226 227 225 65535 65535 65535 18614 18666 18665 18613 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 18615 18637 18658 65535 65535 65535 69 64 65 66 70 65535 65535 65535 65535 65535 65535 65535 68 61 62 63 71 65535 65535 65535 225 227 226 224 67 58 59 60 72 19101 65535 24581 24579 24580 24578 24582 65535 65535 65535 101 44 43 65535 65535 65535 0 24577 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535 65535",
     "layernames": {
       "storageSize": 63,
       "names": [
@@ -1959,7 +2087,7 @@
         "MOUSE",
         "MEDIA",
         "FUN",
-        "NHM",
+        "#7",
         "#8"
       ]
     },

--- a/Atreus/tests/unintended_mods.txt
+++ b/Atreus/tests/unintended_mods.txt
@@ -1,8 +1,21 @@
 This test verifies no unintended modifers are activated
 when using home row mods on the QWERTY layout.
 
+Examples of unintended modifers while typing quickly with
+home row mods in QWERTY layout:
+
+1. typing `less` and activating modifier [Opt] instead of
+   `l`, resulting in Opt+L instead of `le`.
+
+2. typing `could` and activating modifier [Opt] instead of
+   `l`, resulting in Opt+D instead of `ld`.
+
+3. typing `add ` and activating modifier [Cmd] instead of
+   `d`, resulting in Cmd+space instead of `d `.
+
 Type the following as quickly as possible and repeat each
 line 3-5 times. Expect no unintended modifiers.
 
+could could could  add less add less again
 add less add less add less less less again
-add less add less add less less less again
+could could could could again


### PR DESCRIPTION
Includes customizations for Qukeys and accompanying macros to dynamically control the Qukeys tap-repeat behavior which allows me to more effortlessly use home row mods on the Atreus.

Specifically, these updates are to address the following:

* unintentionally activating modifiers using home row mods while typing quickly
* quickly repeated typed home row keys not being registered (e.g, typing "less" and only registering one "s")
* losing tap-hold repeat behavior on keys with secondary modifiers 

See README for complete description.