### PR TITLE
Using Kaleidoscope from Chrysalis

### DIFF
--- a/Model100/Model100.ino
+++ b/Model100/Model100.ino
@@ -29,6 +29,9 @@
 // Support for controlling the keyboard's LEDs
 #include "Kaleidoscope-LEDControl.h"
 
+// Support for "Numpad" mode, which is mostly just the Numpad specific LED mode
+#include "Kaleidoscope-NumPad.h"
+
 // Support for the "Boot greeting" effect, which pulses the 'LED' button for 10s
 // when the keyboard is connected to a computer (or that computer is powered on)
 #include "Kaleidoscope-LEDEffect-BootGreeting.h"
@@ -59,9 +62,6 @@
 
 // Support for turning the LEDs off after a certain amount of time
 #include "Kaleidoscope-IdleLEDs.h"
-
-// Support for overlaying colors
-#include "Kaleidoscope-Colormap-Overlay.h"
 
 // Support for setting and saving the default LED mode
 #include "Kaleidoscope-DefaultLEDModeConfig.h"
@@ -100,6 +100,11 @@
 // Support for the GeminiPR Stenography protocol
 #include "Kaleidoscope-Steno.h"
 
+// My custom qukey settings and macros
+#include "Qukey-Macros.h"
+
+MMQukeys QukeysTapRepeat;
+
 /** This 'enum' is a list of all the macros used by the Model 100's firmware
   * The names aren't particularly important. What is important is that each
   * is unique.
@@ -137,20 +142,6 @@ enum {
   MACROS_QUKEYS_TAP_REPEAT_TIMEOUT_TOGGLE_MAX, // 6
 };
 
-#define QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT 120
-#define QUKEYS_TAP_REPEAT_TIMEOUT_MIN     100
-#define QUKEYS_TAP_REPEAT_TIMEOUT_MAX     220
-#define QUKEYS_TAP_REPEAT_TIMEOUT_DELTA   10
-
-// Qukeys Tap-Repeat State
-typedef enum {
-  QTR_STATE_ENABLED,
-  QTR_STATE_OFF,
-  QTR_STATE_MAX
-} QtrState_t;
-
-QtrState_t QukeysTapRepeatState = QTR_STATE_ENABLED;
-uint8_t QukeysTapRepeatTimeout = QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT;
 
 /** The Model 100's key layouts are defined as 'keymaps'. By default, there are three
   * keymaps: The standard QWERTY keymap, the "Function layer" keymap and the "Numpad"
@@ -342,37 +333,6 @@ KEYMAPS(
 /* Re-enable astyle's indent enforcement */
 // clang-format on
 
-#define RGB_UNSET CRGB(0x00, 0x00, 0x00)
-#define RGB_RED   CRGB(0xff, 0x00, 0x00)
-
-// Set up a default palette to be use for the Colormap and Colormap-Overlay
-// plugins
-PALETTE(
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_UNSET,
-  RGB_RED)  // PALETTE(
-
 /** versionInfoMacro handles the 'firmware version info' macro
  *  When a key bound to the macro is pressed, this macro
  *  prints out the firmware build information as virtual keystrokes
@@ -401,95 +361,6 @@ static void anyKeyMacro(KeyEvent &event) {
 }
 
 
-void typeDigit(uint8_t digit) {
-  // Using Macros type the single digit 0-9
-  if (digit > 9) {
-    Macros.type(PSTR("???"));
-    return;
-  }
-  const char* digits[] = {
-    PSTR("0"), PSTR("1"), PSTR("2"), PSTR("3"), PSTR("4"), PSTR("5"), PSTR("6"), PSTR("7"), PSTR("8"), PSTR("9")
-  };
-  Macros.type(digits[digit]);
-}
-
-void typeValue(uint8_t value) {
-  // Using Macros type each digit of the value given an unsigned 8-bit value.
-  // pretty pathetic but for small numbers it's okay.
-  if (value >= 10) {
-    uint8_t digit = value % 10;
-    value = value / 10;
-    typeValue(value); // will never recurse more than 3 times.
-    typeDigit(digit);
-  } else {
-    typeDigit(value);
-  }
-}
-
-void typeQukeysTapRepeatTimeout() {
-  // Using Macros type the value for Qukeys tap-repeat timeout
-  Macros.type(PSTR("Keyboardio Atreus Qukeys tap-repeat: "));
-  typeValue(QukeysTapRepeatTimeout);
-  if (QukeysTapRepeatState == QTR_STATE_OFF) {
-    Macros.type(PSTR(" [TOGGLED OFF]"));
-  }
-  else if (QukeysTapRepeatState == QTR_STATE_MAX) {
-    Macros.type(PSTR(" [TOGGLED MAX]"));
-  }
-  Macros.type(PSTR(" MIN="));
-  typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_MIN);
-  Macros.type(PSTR(" MAX="));
-  typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_MAX);
-  Macros.type(PSTR(" DEFAULT="));
-  typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT);
-  Macros.type(PSTR(" DELTA="));
-  typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_DELTA);
-}
-
-void increaseQukeysTapRepeatTimeout() {
-  // increase the tap-repeat timeout value and switch state to enabled if in another state
-  QukeysTapRepeatTimeout =
-    min(QukeysTapRepeatTimeout + QUKEYS_TAP_REPEAT_TIMEOUT_DELTA, QUKEYS_TAP_REPEAT_TIMEOUT_MAX);
-  Qukeys.setMaxIntervalForTapRepeat(QukeysTapRepeatTimeout);
-  QukeysTapRepeatState = QTR_STATE_ENABLED;
-}
-
-void decreaseQukeysTapRepeatTimeout() {
-  // decrease the tap-repeat timeout value and switch state to enabled if in another state
-  QukeysTapRepeatTimeout =
-    max(QukeysTapRepeatTimeout - QUKEYS_TAP_REPEAT_TIMEOUT_DELTA, QUKEYS_TAP_REPEAT_TIMEOUT_MIN);
-  Qukeys.setMaxIntervalForTapRepeat(QukeysTapRepeatTimeout);
-  QukeysTapRepeatState = QTR_STATE_ENABLED;
-}
-
-void toggleOffQukeysTapRepeatTimeout() {
-  // toggle tap-repeat between off/previous value
-  // if toggled off, toggle back to enabled.
-  // if enabled or if toggled to max, toggle to off.
-  if (QukeysTapRepeatState == QTR_STATE_OFF) {
-    Qukeys.setMaxIntervalForTapRepeat(QukeysTapRepeatTimeout);
-    QukeysTapRepeatState = QTR_STATE_ENABLED;
-  }
-  else {
-    Qukeys.setMaxIntervalForTapRepeat(0);
-    QukeysTapRepeatState = QTR_STATE_OFF;
-  }
-}
-
-void toggleMaxQukeysTapRepeatTimeout() {
-  // toggle tap-repeat between max/previous value
-  // if toggled to max, toggle back to enabled
-  // if enabled or togged to off, toggle to max
-  if (QukeysTapRepeatState == QTR_STATE_MAX) {
-    Qukeys.setMaxIntervalForTapRepeat(QukeysTapRepeatTimeout);
-    QukeysTapRepeatState = QTR_STATE_ENABLED;
-  }
-  else {
-    Qukeys.setMaxIntervalForTapRepeat(QUKEYS_TAP_REPEAT_TIMEOUT_MAX);
-    QukeysTapRepeatState = QTR_STATE_MAX;
-  }
-}
-
 /** macroAction dispatches keymap events that are tied to a macro
     to that macro. It takes two uint8_t parameters.
 
@@ -515,23 +386,23 @@ const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
       break;
 
     case MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_INFO:
-      typeQukeysTapRepeatTimeout();
+      QukeysTapRepeat.typeQukeysTapRepeatTimeout();
       break;
 
     case MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_INC:
-      increaseQukeysTapRepeatTimeout();
+      QukeysTapRepeat.increaseQukeysTapRepeatTimeout();
       break;
 
     case MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_DEC:
-      decreaseQukeysTapRepeatTimeout();
+      QukeysTapRepeat.decreaseQukeysTapRepeatTimeout();
       break;
 
     case MACRO_QUKEYS_TAP_REPEAT_TIMEOUT_TOGGLE_OFF:
-      toggleOffQukeysTapRepeatTimeout();
+      QukeysTapRepeat.toggleOffQukeysTapRepeatTimeout();
       break;
 
     case MACROS_QUKEYS_TAP_REPEAT_TIMEOUT_TOGGLE_MAX:
-      toggleMaxQukeysTapRepeatTimeout();
+      QukeysTapRepeat.toggleMaxQukeysTapRepeatTimeout();
       break;
     }
   }
@@ -763,10 +634,9 @@ KALEIDOSCOPE_INIT_PLUGINS(
   // The Colormap effect makes it possible to set up per-layer colormaps
   ColormapEffect,
 
-  // The colormap overlay plugin provides a way to set LED colors regardless of
-  // the active LED effect. This is used for lighting up the keys assigned in
-  // the factory 'numpad' mode
-  ColormapOverlay,
+  // The numpad plugin is responsible for lighting up the 'numpad' mode
+  // with a custom LED effect
+  NumPad,
 
   // The HostPowerManagement plugin allows us to turn LEDs off when then host
   // goes to sleep, and resume them when it wakes up.
@@ -798,43 +668,13 @@ void setup() {
   // First, call Kaleidoscope's internal setup function
   Kaleidoscope.setup();
 
-  // Add colormap overlays for all keys of the numpad. This makes sure that
-  // all keys of the numpad light up once the numpad layer is active.
-  //
-  // The call signature is:
-  // kaleidoscope::plugin::Overlay(<layer>, <key_address>, <palette_index>)
-  //
-  // Key address matrix: https://github.com/keyboardio/Kaleidoscope/blob/master/plugins/Kaleidoscope-Hardware-Keyboardio-Model100/src/kaleidoscope/device/keyboardio/Model100.h#L175-L205
-  //
-  // (0, 0) (0, 1) (0, 2) (0, 3) (0, 4) (0, 5) (0, 6) | (0, 9) (0, 10) (0, 11) (0, 12) (0, 13) (0, 14) (0, 15)
-  // (1, 0) (1, 1) (1, 2) (1, 3) (1, 4) (1, 5) (1, 6) | (1, 9) (1, 10) (1, 11) (1, 12) (1, 13) (1, 14) (1, 15)
-  // (2, 0) (2, 1) (2, 2) (2, 3) (2, 4) (2, 5)        |        (2, 10) (2, 11) (2, 12) (2, 13) (2, 14) (2, 15)
-  // (3, 0) (3, 1) (3, 2) (3, 3) (3, 4) (3, 5) (2, 6) | (2, 9) (3, 10) (3, 11) (3, 12) (3, 13) (3, 14) (3, 15)
-  //                      (0, 7) (1, 7) (2, 7) (3, 7) | (3, 8) (2, 8)  (1, 8)  (0, 8)
-  //                                           (3, 6) | (3, 9)
-  COLORMAP_OVERLAYS(
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(0, 11), 23),  // 7
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(1, 11), 23),  // 4
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(2, 11), 23),  // 1
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(3, 11), 23),  // 0
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(0, 12), 23),  // 8
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(1, 12), 23),  // 5
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(2, 12), 23),  // 2
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(3, 12), 23),  // period
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(0, 13), 23),  // 9
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(1, 13), 23),  // 6
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(2, 13), 23),  // 3
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(3, 13), 23),  // multiply
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(0, 14), 23),  // substract
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(1, 14), 23),  // add
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(2, 14), 23),  // equals
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(3, 14), 23),  // divide
-    kaleidoscope::plugin::Overlay(NUMPAD, KeyAddr(3, 15), 23),  // enter
-    )                                                           // COLORMAP_OVERLAYS(
-
   // Set the hue of the boot greeting effect to something that will result in a
   // nice green color.
   BootGreetingEffect.hue = 85;
+
+  // While we hope to improve this in the future, the NumPad plugin
+  // needs to be explicitly told which keymap layer is your numpad layer
+  NumPad.numPadLayer = NUMPAD;
 
   // We configure the AlphaSquare effect to use RED letters
   AlphaSquare.color = CRGB(255, 0, 0);
@@ -863,7 +703,6 @@ void setup() {
   // maps for. To make things simple, we set it to eight layers, which is how
   // many editable layers we have (see above).
   ColormapEffect.max_layers(8);
-  DefaultColormap.setup();
 
   // For Dynamic Macros, we need to reserve storage space for the editable
   // macros. A kilobyte is a reasonable default.
@@ -890,10 +729,7 @@ void setup() {
 
   // Tweak Qukeys to prevent unintended modifiers with home row mods:
   // https://kaleidoscope.readthedocs.io/en/latest/plugins/Kaleidoscope-Qukeys.html
-  Qukeys.setOverlapThreshold(100);         // default 80
-  Qukeys.setMinimumHoldTime(500);          // default 50
-  Qukeys.setMinimumPriorInterval(350);     // default 75
-  Qukeys.setMaxIntervalForTapRepeat(QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT);  // default 200
+  QukeysTapRepeat.reset();
 }
 
 /** loop is the second of the standard Arduino sketch functions.

--- a/Model100/Qukey-Macros.h
+++ b/Model100/Qukey-Macros.h
@@ -1,0 +1,134 @@
+// -*- mode: c++ -*-
+
+/**
+ * Custom Quekey settings and macros.
+ */
+
+#define QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT 120
+#define QUKEYS_TAP_REPEAT_TIMEOUT_MIN     100
+#define QUKEYS_TAP_REPEAT_TIMEOUT_MAX     220
+#define QUKEYS_TAP_REPEAT_TIMEOUT_DELTA   10
+
+class MMDebug
+{
+  public:
+
+    static void typeDigit(uint8_t digit) {
+      // Using Macros type the single digit 0-9
+      if (digit > 9) {
+        Macros.type(PSTR("???"));
+        return;
+      }
+      const char* digits[] = {
+        PSTR("0"), PSTR("1"), PSTR("2"), PSTR("3"), PSTR("4"), PSTR("5"), PSTR("6"), PSTR("7"), PSTR("8"), PSTR("9")
+      };
+      Macros.type(digits[digit]);
+    }
+
+    static void typeValue(uint8_t value) {
+      // Using Macros type each digit of the value given an unsigned 8-bit value.
+      // pretty pathetic but for small numbers it's okay.
+      if (value >= 10) {
+        uint8_t digit = value % 10;
+        value = value / 10;
+        typeValue(value); // will never recurse more than 3 times.
+        typeDigit(digit);
+      } else {
+        typeDigit(value);
+      }
+    }
+};
+
+class MMQukeys
+{
+  public:
+
+  // Qukeys Tap-Repeat State
+  typedef enum {
+    QTR_STATE_ENABLED,
+    QTR_STATE_OFF,
+    QTR_STATE_MAX
+  } QtrState_t;
+
+  MMQukeys() {
+    reset();
+  }
+
+  ~MMQukeys() {
+  }
+
+  void reset() {
+    _qtr_state = QTR_STATE_ENABLED;
+    _qtr_timeout = QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT;
+    Qukeys.setOverlapThreshold(100);
+    Qukeys.setMinimumHoldTime(500);
+    Qukeys.setMinimumPriorInterval(350);
+    Qukeys.setMaxIntervalForTapRepeat(QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT);
+  }
+
+  void increaseQukeysTapRepeatTimeout() {
+    // increase the tap-repeat timeout value and switch state to enabled if in another state
+    _qtr_timeout = min(_qtr_timeout + QUKEYS_TAP_REPEAT_TIMEOUT_DELTA, QUKEYS_TAP_REPEAT_TIMEOUT_MAX);
+    Qukeys.setMaxIntervalForTapRepeat(_qtr_timeout);
+    _qtr_state = QTR_STATE_ENABLED;
+  }
+
+  void decreaseQukeysTapRepeatTimeout() {
+    // decrease the tap-repeat timeout value and switch state to enabled if in another state
+    _qtr_timeout = max( _qtr_timeout - QUKEYS_TAP_REPEAT_TIMEOUT_DELTA, QUKEYS_TAP_REPEAT_TIMEOUT_MIN);
+    Qukeys.setMaxIntervalForTapRepeat( _qtr_timeout);
+    _qtr_state = QTR_STATE_ENABLED;
+  }
+
+  void toggleOffQukeysTapRepeatTimeout() {
+    // toggle tap-repeat between off/previous value
+    // if toggled off, toggle back to enabled.
+    // if enabled or if toggled to max, toggle to off.
+    if (_qtr_state == QTR_STATE_OFF) {
+      Qukeys.setMaxIntervalForTapRepeat(_qtr_timeout);
+      _qtr_state = QTR_STATE_ENABLED;
+    }
+    else {
+      Qukeys.setMaxIntervalForTapRepeat(0);
+      _qtr_state = QTR_STATE_OFF;
+    }
+  }
+
+  void toggleMaxQukeysTapRepeatTimeout() {
+    // toggle tap-repeat between max/previous value
+    // if toggled to max, toggle back to enabled
+    // if enabled or togged to off, toggle to max
+    if (_qtr_state == QTR_STATE_MAX) {
+      Qukeys.setMaxIntervalForTapRepeat(_qtr_timeout);
+      _qtr_state = QTR_STATE_ENABLED;
+    }
+    else {
+      Qukeys.setMaxIntervalForTapRepeat(QUKEYS_TAP_REPEAT_TIMEOUT_MAX);
+      _qtr_state = QTR_STATE_MAX;
+    }
+  }
+
+  void typeQukeysTapRepeatTimeout() {
+    // Using Macros type the value for Qukeys tap-repeat timeout
+    Macros.type(PSTR("Keyboardio Qukeys tap-repeat: "));
+    MMDebug::typeValue(_qtr_timeout);
+    if (_qtr_state == QTR_STATE_OFF) {
+      Macros.type(PSTR(" [TOGGLED OFF]"));
+    }
+    else if (_qtr_state == QTR_STATE_MAX) {
+      Macros.type(PSTR(" [TOGGLED MAX]"));
+    }
+    Macros.type(PSTR(" MIN="));
+    MMDebug::typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_MIN);
+    Macros.type(PSTR(" MAX="));
+    MMDebug::typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_MAX);
+    Macros.type(PSTR(" DEFAULT="));
+    MMDebug::typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_DEFAULT);
+    Macros.type(PSTR(" DELTA="));
+    MMDebug::typeValue(QUKEYS_TAP_REPEAT_TIMEOUT_DELTA);
+  }
+
+  private:
+    QtrState_t _qtr_state;
+    uint8_t _qtr_timeout;
+};


### PR DESCRIPTION
Moving back to the [Kaleidoscope](https://github.com/keyboardio/Kaleidoscope) commit which is bundled with [Chrysalis](https://github.com/keyboardio/Chrysalis), because it appears to be more stable with regards to secondary key actions.

This fixes an issue with secondary modifier actions where `shift` as a secondary modifier (`shift` when held; normal when tapped) to home row keys `G` and `H` was not registering the modifier action when held. Other modifiers as secondary worked normally. 